### PR TITLE
Remove custom ad-hoc z-index from background container

### DIFF
--- a/packages/background-container/src/scss/styles.scss
+++ b/packages/background-container/src/scss/styles.scss
@@ -67,7 +67,6 @@
 
   &__content {
     position: relative;
-    z-index: 1;
   }
 
   @import "hub-geometric-topleft";


### PR DESCRIPTION
# Description:
It's unclear now exactly why we were monkeying around with z-index values back in 2022 when the background container was first made...but I have a suspicion that such overrides are no longer needed.

Let's remove it and see what happens.  I've tapped Matt in for testing.