### PR TITLE
Eliminate troublesome component cross-pollination of cta-group with other components

### DIFF
--- a/packages/cta/package.json
+++ b/packages/cta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-online-education/cta",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Provides a CTA button.",
   "publishConfig": {
     "access": "public",

--- a/packages/cta/src/scss/styles.scss
+++ b/packages/cta/src/scss/styles.scss
@@ -11,7 +11,6 @@
   }
 
   &--expand-to-fit {
-    //display:flex;
     width: 100%;
     justify-content: space-between;
 
@@ -19,8 +18,4 @@
       flex: 1 1 auto;
     }
   }
-
-  //& > .cta-block:not(:last-of-type) {
-  //  margin-right: clamp(oe.rem(.5), 1.25vw, oe.rem(1));
-  //}
 }

--- a/packages/cta/src/scss/styles.scss
+++ b/packages/cta/src/scss/styles.scss
@@ -4,7 +4,7 @@
   display: flex;
   min-width: oe.rem(10);
 
-  column-gap: clamp(0.5rem, 1.25vw, 1rem);
+  column-gap: clamp(oe.rem(0.5), 1.25vw, oe.rem(1));
 
   &--align-right {
     text-align: right;

--- a/packages/cta/src/scss/styles.scss
+++ b/packages/cta/src/scss/styles.scss
@@ -4,6 +4,8 @@
   display: flex;
   min-width: oe.rem(10);
 
+  column-gap: clamp(0.5rem, 1.25vw, 1rem);
+
   &--align-right {
     text-align: right;
   }
@@ -18,7 +20,7 @@
     }
   }
 
-  & > .cta-block:not(:last-of-type) {
-    margin-right: clamp(oe.rem(.5), 1.25vw, oe.rem(1));
-  }
+  //& > .cta-block:not(:last-of-type) {
+  //  margin-right: clamp(oe.rem(.5), 1.25vw, oe.rem(1));
+  //}
 }

--- a/packages/cta/src/scss/styles.scss
+++ b/packages/cta/src/scss/styles.scss
@@ -11,8 +11,8 @@
   }
 
   &--expand-to-fit {
-    display:flex;
-    width:100%;
+    //display:flex;
+    width: 100%;
     justify-content: space-between;
 
     > .cta-block {

--- a/packages/cta/src/scss/styles.scss
+++ b/packages/cta/src/scss/styles.scss
@@ -15,14 +15,6 @@
 
     > .cta-block {
       flex: 1 1 auto;
-
-      &:not(.cta-block--compact, .cta-block--xcompact, .cta-block--compact-responsive) {
-        padding: oe.rem(1.5);
-
-        @include oe.bp(m) {
-          padding: oe.rem(1.7);
-        }
-      }
     }
   }
 


### PR DESCRIPTION
Description:
Fixing up a couple of issues:
- Setting a column-gap property on cta-group instead of a margin right on cta-block, using the same clamp values.
- Removing a redundant display: flex from the --expand-to-fit modifier.

Review environment Link
https://developers.worldcampus.psu.edu/cta-group-issues/?p=viewall-molecules-cta-group
