### PR TITLE
12 allow reversed modifier for light backgrounds for button base

### DIFF
--- a/packages/button-base/package.json
+++ b/packages/button-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-online-education/button-base",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Provides generic button-like element styles.",
   "publishConfig": {
     "access": "public",

--- a/packages/button-base/src/scss/styles.scss
+++ b/packages/button-base/src/scss/styles.scss
@@ -148,6 +148,7 @@
 @include button.color-light('keystone-light', var(--keystone-light), var(--nittany-navy), var(--keystone), var(--nittany-navy), var(--nittany-navy));
 @include button.color-light('hollow-solid', transparent, var(--beaver-blue), var(--pugh-blue), var(--nittany-navy), var(--nittany-navy));
 @include button.color-light('hollow-dotted', transparent, var(--beaver-blue), var(--pugh-blue), var(--nittany-navy), var(--nittany-navy));
+@include button.color-light('reversed', var(--white), var(--beaver-blue),var(--keystone-light), var(--beaver-blue), var(--nittany-navy));
 @include button.color-light('light-blue', var(--pa-link-light), var(--beaver-blue), var(--keystone-light), var(--beaver-blue), var(--nittany-navy));
 
 @include button.color-dark('keystone', var(--keystone), var(--nittany-navy), var(--invent-orange-light), var(--black), var(--nittany-navy));

--- a/packages/button/button.twig
+++ b/packages/button/button.twig
@@ -3,8 +3,8 @@
 
 {%- set classes = classes|default([])|merge([
   'button',
-  color in ['alt', 'keystone', 'keystone-light', 'hollow-solid', 'hollow-dotted', 'light-blue'] ? 'button--' ~ color,
-  color_on_dark in ['keystone', 'keystone-light', 'light-blue'] ? 'button--on-dark-' ~ color_on_dark,
+  color in ['alt', 'keystone', 'keystone-light', 'reversed', 'hollow-solid', 'hollow-dotted', 'light-blue'] ? 'button--' ~ color,
+  color_on_dark in ['keystone', 'keystone-light', 'reversed', 'light-blue'] ? 'button--on-dark-' ~ color_on_dark,
   expand_to_fit ? 'button--expand-to-fit',
   font_weight in ['bold'] ? 'button--' ~ font_weight,
   size in ['medium', 'xcompact', 'compact', 'compact-responsive'] ? 'button--' ~ size,

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-online-education/button",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Provides a stylized semantic button.",
   "publishConfig": {
     "access": "public",

--- a/packages/cta/cta-block.twig
+++ b/packages/cta/cta-block.twig
@@ -2,7 +2,7 @@
 {%- set classes = classes|default([])|merge([
   'cta-block',
   'button',
-  color in ['alt', 'keystone', 'keystone-light', 'hollow-solid', 'hollow-dotted', 'light-blue', 'expand'] ? 'button--' ~ color,
+  color in ['alt', 'keystone', 'keystone-light', 'reversed', 'hollow-solid', 'hollow-dotted', 'light-blue', 'expand'] ? 'button--' ~ color,
   color_on_dark in ['keystone', 'keystone-light', 'reversed', 'light-blue'] ? 'button--on-dark-' ~ color_on_dark,
   expand_to_fit ? 'button--expand-to-fit',
   font_weight in ['bold'] ? 'button--' ~ font_weight,

--- a/packages/cta/package.json
+++ b/packages/cta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-online-education/cta",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Provides a CTA button.",
   "publishConfig": {
     "access": "public",

--- a/packages/patternlab/package.json
+++ b/packages/patternlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-online-education/patternlab",
-  "version": "2.0.48",
+  "version": "2.0.49",
   "publishConfig": {
     "access": "public",
     "registry": "https://npm.pkg.github.com/"

--- a/packages/patternlab/source/patterns/atoms/cta/cta~auto-contrast.twig
+++ b/packages/patternlab/source/patterns/atoms/cta/cta~auto-contrast.twig
@@ -15,7 +15,8 @@
     'Hollow Dotted | Light Blue': ['hollow-dotted', 'light-blue'],
     'Light Blue | Reversed': ['light-blue', 'reversed'],
     'Light Blue | Keystone': ['light-blue', 'keystone'],
-    'Light Blue | Light Blue': ['light-blue', 'light-blue']
+    'Light Blue | Light Blue': ['light-blue', 'light-blue'],
+    'Reversed | Reversed': ['reversed', 'reversed'],
   } %}
   {% for label, colors in buttons %}
     {% include '@oe/cta/cta-block.twig' with {

--- a/packages/patternlab/source/patterns/molecules/button/button~color-options.twig
+++ b/packages/patternlab/source/patterns/molecules/button/button~color-options.twig
@@ -25,7 +25,7 @@
 
   {%- include '@oe/button/button.twig' with {
     type: 'button',
-    label: 'Light blue',
+    label: 'Reversed',
     icon_before: 'fa-chevron-left',
     icon_after: 'fas-chevron-right',
     color: 'reversed',

--- a/packages/patternlab/source/patterns/molecules/button/button~color-options.twig
+++ b/packages/patternlab/source/patterns/molecules/button/button~color-options.twig
@@ -25,6 +25,14 @@
 
   {%- include '@oe/button/button.twig' with {
     type: 'button',
+    label: 'Light blue',
+    icon_before: 'fa-chevron-left',
+    icon_after: 'fas-chevron-right',
+    color: 'reversed',
+  } only -%}
+
+  {%- include '@oe/button/button.twig' with {
+    type: 'button',
     label: 'Keystone',
     icon_before: 'fa-chevron-left',
     icon_after: 'fas-chevron-right',


### PR DESCRIPTION
# Description:
Reversed buttons on lighter backgrounds were actually a requirement for program and partner pages.  This PR adds that support back in and some accompanying examples.

## Metadata
### Review environment Link
  https://developers.worldcampus.psu.edu/12-allow-reversed-modifier-for-light-backgrounds-for-button-base/?p=viewall-atoms-cta + https://developers.worldcampus.psu.edu/12-allow-reversed-modifier-for-light-backgrounds-for-button-base/?p=viewall-molecules-button