### PR TITLE
Restore min-heights to compact-menu

### DIFF
--- a/packages/compact-menu/package.json
+++ b/packages/compact-menu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@psu-online-education/compact-menu",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Provides a compact menu block.",
   "publishConfig": {
     "access": "public",

--- a/packages/compact-menu/src/scss/styles.scss
+++ b/packages/compact-menu/src/scss/styles.scss
@@ -86,9 +86,11 @@
       .compact-menu__toggle-sprite .sprite {
         width: oe.rem(2.1);
         height: auto;
+        min-height: oe.rem(2.1);
 
         @include oe.bp(xs) {
           width: oe.rem(2.6);
+          min-height: oe.rem(2.6);
         }
       }
 


### PR DESCRIPTION
# Description:
PR #318 in the legacy repo removed these (due to either oversight or a Figma migration error).

These need to be restored.
## Metadata
### Review environment Link
  https://developers.worldcampus.psu.edu/16-restore-min-heights-to-compact-menu-sprites/?p=viewall-regions-header for how it manifests in the header

  https://developers.worldcampus.psu.edu/16-restore-min-heights-to-compact-menu-sprites/?p=viewall-organisms-sticky-panel for how it manifests in the sticky panel